### PR TITLE
open all ports for easy dev access

### DIFF
--- a/config/rippled.cfg
+++ b/config/rippled.cfg
@@ -8,8 +8,9 @@ port_ws_public
 
 [port_rpc_admin_local]
 port = 5005
-ip = 127.0.0.1
-admin = 127.0.0.1
+ip = 0.0.0.0
+admin = 0.0.0.0
+#^^^^ warning: INSECURE
 protocol = http
 
 [port_ws_public]
@@ -17,16 +18,17 @@ port = 80
 ip = 0.0.0.0
 protocol = ws
 
-# [port_peer]
-# port = 51235
-# ip = 0.0.0.0
-# protocol = peer
+[port_peer]
+port = 51235
+ip = 0.0.0.0
+protocol = peer
 
-# [port_ws_admin_local]
-# port = 6006
-# ip = 127.0.0.1
-# admin = 127.0.0.1
-# protocol = ws
+[port_ws_admin_local]
+port = 6006
+ip = 0.0.0.0
+admin = 0.0.0.0
+#^^^^ warning: INSECURE
+protocol = ws
 
 [node_size]
 small

--- a/config/rippled.cfg
+++ b/config/rippled.cfg
@@ -1,8 +1,8 @@
 [server]
 port_rpc_admin_local
 port_ws_public
-# port_peer
-# port_ws_admin_local
+port_peer
+port_ws_admin_local
 # ssl_key = /etc/ssl/private/server.key
 # ssl_cert = /etc/ssl/certs/server.crt
 

--- a/go/up
+++ b/go/up
@@ -7,19 +7,29 @@ self(){
 
 $(self)/down
 
-PORT=80
+WSPORT=80
 
 CUSTOMPORT=$(echo $1|egrep "^[0-9]+$"|wc -l)
 
 if [[ "$CUSTOMPORT" -gt "0" ]]; then
-    PORT=$1
+    WSPORT=$1
 fi
 
+# note: port designations
+# 80     websocket public api
+# 5005   rpc public api
+# 6006   websocket admin api
+# 51235  peer
+
+# run container
 docker run \
     -dit \
     --name rippled \
-    -p $PORT:80 \
+    -p $WSPORT:80 \
+    -p 5005:5005 \
+    -p 6006:6006 \
+    -p 51235:51235 \
     -v $(self)/../config:/config/ \
-    rippled:latest
+    rippled:latest -a --start 
 
 docker logs -f rippled

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# run this once you have your node running in docker (./go/up)
+
+####################################################################
+###																 ###
+### rippled api documentation: https://xrpl.org/rippled-api.html ###
+###																 ###
+####################################################################
+###																 ###
+### the following api calls use rippled's JSON-RPC endpoints 	 ###
+###																 ###
+####################################################################
+
+# admin call
+curl --data '{
+    "method": "wallet_propose",
+    "params": [
+        {
+            "passphrase": "snoPBrXtMeMyMHUVTgbuqAfg1SUTb"
+        }
+    ]
+}' \
+-H "Content-Type: application/json" -X POST http://localhost:5005
+
+# public method call
+curl --data '{
+    "method": "server_info",
+    "params": [
+        {}
+    ]
+}' \
+-H "Content-Type: application/json" -X POST http://localhost:5005


### PR DESCRIPTION
Also added `-a --start` to launch params to enable standalone (local) node functionality. By default it was running a live net. Not sure which one but you could see the size increasing steadily: `docker ps --size | grep rippled`.